### PR TITLE
Docs: Update README for obsidian-ai-providers integration and manual …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # YouTube Video Summarizer for Obsidian
 
-Generate AI-powered summaries of YouTube videos directly in Obsidian using Google's Gemini AI.
+Generate AI-powered summaries of YouTube videos directly in Obsidian. This plugin leverages the [obsidian-ai-providers](https://github.com/pfrankov/obsidian-ai-providers) hub, allowing you to choose from a variety of AI providers, including:
+
+- Ollama
+- OpenAI
+- OpenAI compatible API
+- OpenRouter
+- Google Gemini
+- LM Studio
+- Groq
 
 ## Demo
 
@@ -9,29 +17,38 @@ Generate AI-powered summaries of YouTube videos directly in Obsidian using Googl
 ## Features
 
 -   🎥 Extract transcripts from YouTube videos
--   🤖 Generate summaries using Gemini AI
+-   🤖 Generate summaries using various AI providers
 -   📝 Create structured notes with key points
 -   🔍 Identify and explain technical terms
 -   📊 Format summaries with metadata and tags
 
-## Installation
-
-1. Open Obsidian Settings
-2. Go to Community Plugins and disable Safe Mode
-3. Click Browse and search for "YouTube Video Summarizer"
-4. Install and enable the plugin
-
 ## Requirements
 
 -   Obsidian v0.15.0+
--   Google Gemini API key ([Get one here](https://aistudio.google.com/app/apikey))
+
+## Manual Installation
+
+This plugin must be installed manually as it is not available in the Community Plugins store.
+
+1.  **Download the Plugin:** Go to the GitHub page of the plugin: [https://github.com/syyckz145/obsidian-yt-video-summarizer](https://github.com/syyckz145/obsidian-yt-video-summarizer). Click the green "Code" button and select "Download ZIP".
+2.  **Unzip the Files:** Unzip the downloaded file. You should now have a folder named something like `obsidian-yt-video-summarizer-main`.
+3.  **Find Your Obsidian Plugins Folder:**
+    *   In Obsidian, go to `Settings` > `Community Plugins`.
+    *   Under "Installed plugins", click the folder icon to open your vault's plugins folder. It's usually located at `YourVaultName/.obsidian/plugins/` (where `YourVaultName` is the name of your Obsidian vault).
+4.  **Copy the Plugin Folder:** Copy the unzipped plugin folder (e.g., `obsidian-yt-video-summarizer-main`) into the plugins folder you just opened.
+5.  **Reload Obsidian:** Go back to Obsidian and, in the "Community Plugins" settings, click the "Reload plugins" button (the circular arrow icon).
+6.  **Enable the Plugin:** Your manually installed plugin should now appear in the list. Enable it by toggling it on.
+
+You will also need to install and configure the [obsidian-ai-providers](https://github.com/pfrankov/obsidian-ai-providers) plugin, which this plugin uses to connect to various AI services.
 
 ## Configuration
 
-1. Open plugin settings
-2. Enter your Gemini API key
-3. Select preferred model
-4. Customize summary prompt (optional)
+1.  **Install and configure `obsidian-ai-providers`:**
+    *   Follow the installation and configuration instructions for the [obsidian-ai-providers](https://github.com/pfrankov/obsidian-ai-providers) plugin.
+    *   Ensure you have correctly set up your desired AI provider (e.g., entered API keys, selected models) within the `obsidian-ai-providers` settings.
+2.  **Configure `obsidian-yt-video-summarizer` (Optional):**
+    *   Open this plugin's settings in Obsidian (`Settings` > `Community Plugins` > `YouTube Video Summarizer`).
+    *   You can customize the summary prompt if needed. The core AI provider settings are managed by `obsidian-ai-providers`.
 
 ## Usage
 


### PR DESCRIPTION
…installation

- Rewrites the README to reflect the use of obsidian-ai-providers hub.
- Lists supported AI providers (Ollama, OpenAI, OpenRouter, Gemini, LM Studio, Groq).
- Removes outdated community plugin installation instructions.
- Adds detailed manual installation instructions from GitHub.
- Updates Configuration section to point to obsidian-ai-providers for API key and model settings.
- Clarifies that this plugin's settings are for optional prompt customization.